### PR TITLE
Updated German translation:

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -8,14 +8,15 @@ msgstr ""
 "Project-Id-Version: pegsolitaire 0.0.4\n"
 "Report-Msgid-Bugs-To: https://github.com/jnumm/pegsolitaire/issues\n"
 "POT-Creation-Date: 2018-01-19 14:34+0200\n"
-"PO-Revision-Date: 2008-05-01 14:44+0200\n"
-"Last-Translator: Mario Blättermann <mario.blaettermann@t-online.de>\n"
+"PO-Revision-Date: 2018-01-20 10:39+0100\n"
+"Last-Translator: Markus Enzenberger <enz@users.sourceforge.net>\n"
 "Language-Team: German\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.0.4\n"
 
 #: data/com.github.jnumm.pegsolitaire.desktop.in:4
 #: data/com.github.jnumm.pegsolitaire.appdata.xml.in:8
@@ -27,11 +28,13 @@ msgstr "Peg Solitaire"
 #: data/com.github.jnumm.pegsolitaire.desktop.in:5
 #: data/com.github.jnumm.pegsolitaire.appdata.xml.in:9
 msgid "Play an educational puzzle game similar to Hi-Q"
-msgstr "Spiele ein lehrreiches Knobelspiel ähnlich wie Hi-Q"
+msgstr "Spiele ein lehrreiches Knobelspiel ähnlich wie Solitär"
 
 #: data/com.github.jnumm.pegsolitaire.desktop.in:10
 msgid "solitaire;peg;brainvita;solo;noble;puzzle;logic;board;"
 msgstr ""
+"Solitär;Solitaire;Steckhalma;Solohalma;Springer;Jumper;Nonnenspiel;"
+"Einsiedlerspiel;Stift;Einzelspieler;Knobelspiel;Brettspiel;"
 
 #: data/com.github.jnumm.pegsolitaire.appdata.xml.in:12
 msgid ""
@@ -40,6 +43,11 @@ msgid ""
 "central hole. The objective is, making valid moves, to empty the entire "
 "board except for a solitary peg in the central hole."
 msgstr ""
+"Peg Solitaire (Solitär) ist ein Brettspiel für eine Person, bei dem Stifte "
+"auf einem Brett mit Löchern gezogen werden. Zuerst ist das ganze Brett mit "
+"Stiften gefüllt außer das Loch in der Mitte. Ziel ist es, das ganze Brett "
+"durch legale Züge zu leeren, sodass nur ein einzelner Stift in der Mitte "
+"übrigbleibt."
 
 #: data/pegsolitaire.glade:40
 msgid "_Game"
@@ -82,6 +90,8 @@ msgid ""
 "© 2007-2008 Ben Asselstine\n"
 "© 2017-2018 Juhani Numminen"
 msgstr ""
+"© 2007-2008 Ben Asselstine\n"
+"© 2017-2018 Juhani Numminen"
 
 #: data/pegsolitaire.glade:264
 msgid ""
@@ -94,7 +104,9 @@ msgstr ""
 #. TRANSLATORS: Replace this string with your names, one name per line.
 #: data/pegsolitaire.glade:268
 msgid "translator-credits"
-msgstr "Deutsch: Mario Blättermann <mario.blaettermann@t-online.de>"
+msgstr ""
+"Mario Blättermann <mario.blaettermann@t-online.de>\n"
+"Markus Enzenberger"
 
 #: src/game.c:365
 msgid "GENIUS!"
@@ -132,7 +144,7 @@ msgstr "Züge: %d"
 
 #: src/main.c:103
 msgid "X location of window"
-msgstr "X Fensterposition"
+msgstr "X-Fensterposition"
 
 #: src/main.c:104
 msgid "X"
@@ -140,7 +152,7 @@ msgstr "X"
 
 #: src/main.c:105
 msgid "Y location of window"
-msgstr "Y Fensterposition"
+msgstr "Y-Fensterposition"
 
 #: src/main.c:106
 msgid "Y"
@@ -160,28 +172,26 @@ msgstr ""
 "Bitte überprüfen Sie die korrekte Installation von Peg Solitaire."
 
 #: src/callbacks.c:131
-#, fuzzy
 msgid ""
 "The theme for this game failed to render.\n"
 "\n"
 "Please check that Peg Solitaire is installed correctly."
 msgstr ""
 "Konnte Bilddatei nicht finden:\n"
-"%s\n"
 "\n"
 "Bitte überprüfen Sie die korrekte Installation von Peg Solitaire."
 
 #: src/callbacks.c:210
 #, c-format
 msgid "Cannot show help: %s"
-msgstr ""
+msgstr "Hilfe wurde nicht gefunden: %s"
 
 #: src/callbacks.c:368
 #, c-format
 msgid "The \"%s\" cursor is not available"
-msgstr ""
+msgstr "Der Cursor \"%s\" wurde nicht gefunden"
 
 #: src/callbacks.c:375 src/callbacks.c:383
 #, c-format
 msgid "The \"%s\" or \"%s\" cursor is not available"
-msgstr ""
+msgstr "Der Cursor \"%s\" oder \"%s\" wurde nicht gefunden"


### PR DESCRIPTION
* Added missing translations.
* Updated fuzzy translation.
* Replaced reference to Hi-Q, which is mostly unknown in Germany,
  by "Solitär", under which name the game is widely known in Germany.
* Correct German spelling requires hyphen in compound nouns
  (e.g. "X-Fensterposition").